### PR TITLE
Trusty: Update definition of VIRTIO_ID_TRUSTY_IPC

### DIFF
--- a/include/uapi/linux/virtio_ids.h
+++ b/include/uapi/linux/virtio_ids.h
@@ -39,7 +39,7 @@
 #define VIRTIO_ID_9P		9 /* 9p virtio console */
 #define VIRTIO_ID_RPROC_SERIAL 11 /* virtio remoteproc serial link */
 #define VIRTIO_ID_CAIF	       12 /* Virtio caif */
-#define VIRTIO_ID_TRUSTY_IPC   13 /* virtio trusty ipc */
+#define VIRTIO_ID_TRUSTY_IPC   14 /* virtio trusty ipc */
 #define VIRTIO_ID_GPU          16 /* virtio GPU */
 #define VIRTIO_ID_INPUT        18 /* virtio input */
 #define VIRTIO_ID_VSOCK        19 /* virtio vsock transport */


### PR DESCRIPTION
VIRTIO ID 13 is used by VIRTIO_ID_MEMORY_BALLOON in kernel 5.15. 
In order to upgrade Android kernel to 5.15 with Trusty support seamlessly,
need to update definition of VIRTIO_ID_TRUSTY_IPC from 13 to 14, since
14 has not been used yet.
With this change, definition of VIRTIO_ID_TIPC in Trusty side should also
update from 13 to 14 to match changes in Android kernel changes.